### PR TITLE
Correction plural naming of types + pointer reference of type

### DIFF
--- a/internal/leagues/leagues.go
+++ b/internal/leagues/leagues.go
@@ -5,19 +5,19 @@ import "github.com/mjl776/sports-management-platform/internal/teams"
 type SportType struct {
 	ID string `json:"id"`
 	Category string `json:"category"`
-	Sports map[string]Sports `json:"sports"`
+	Sports map[string]*Sport `json:"sports"`
 }
 
-type Sports struct {
+type Sport struct {
 	ID string `json:"id"`
 	Name string `json:"name"`
-	Leagues map[string]Leagues `json:"leagues"`
+	Leagues map[string]*League `json:"leagues"`
 }
 
-type Leagues struct {
+type League struct {
 	ID int  `json:"id"`
 	Name string `json:"name"`
-	Teams map[string]teams.Team `json:"teams"`
+	Teams map[string]*teams.Team `json:"teams"`
 }
 
 


### PR DESCRIPTION
### **Overview of Changes:**

This PR amends some issues in regard to the original type creations of types in the leagues file storing a map of the actual data type rather than a memory pointer of that type. This PR also amends some naming conventions